### PR TITLE
Feature/signup email verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ out/
 src/main/resources/app.key
 src/main/resources/app.pub
 
-!**/src/main/generated
+/src/main/generated/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ out/
 ### Custom Private Keys ###
 src/main/resources/app.key
 src/main/resources/app.pub
+
+!**/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     //yml 암호화, 공식문서: https://github.com/ulisesbocchio/jasypt-spring-boot
     //참고 블로그: https://velog.io/@bey1548/SpringBoot-application.yml-%EA%B0%92-%EC%95%94%ED%98%B8%ED%99%94%ED%95%98%EA%B8%B0jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    //mail 전송 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ dependencies {
 
     //mail 전송 의존성
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //Redis 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/store/clothstar/common/config/RedisConfig.java
+++ b/src/main/java/org/store/clothstar/common/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package org.store.clothstar.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/org/store/clothstar/common/config/SecurityConfiguration.java
+++ b/src/main/java/org/store/clothstar/common/config/SecurityConfiguration.java
@@ -57,7 +57,7 @@ public class SecurityConfiguration {
                         "/v1/categories/**", "/v1/products/**", "/v1/productLines/**", "/v2/productLines/**",
                         "/v1/orderdetails", "/v1/orders",
                         "/v1/seller/orders/**", "/v1/seller/orders", "/v1/orders/**",
-                        "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**"
+                        "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**", "/v1/members/auth/**"
                 ).permitAll()
                 .requestMatchers(HttpMethod.POST, "/v1/members").permitAll()
                 .requestMatchers(HttpMethod.POST, "/v1/sellers/**").authenticated()

--- a/src/main/java/org/store/clothstar/common/config/jwt/LoginFilter.java
+++ b/src/main/java/org/store/clothstar/common/config/jwt/LoginFilter.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -93,13 +95,26 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
                                               AuthenticationException failed) throws IOException, ServletException {
         log.info("로그인 실패");
+
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json");
 
-        MessageDTO messageDTO = MessageDTOBuilder.buildMessage(HttpServletResponse.SC_UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다. 다시 확인해주세요.");
+        MessageDTO messageDTO = MessageDTOBuilder.buildMessage(HttpServletResponse.SC_UNAUTHORIZED, errorMessage(failed));
         ObjectMapper om = new ObjectMapper();
 
         response.getWriter().print(om.writeValueAsString(messageDTO));
+    }
+
+    private String errorMessage(AuthenticationException failed) {
+        String errorMessage = null;
+
+        if (failed instanceof BadCredentialsException) {
+            errorMessage = "이메일 또는 비밀번호가 올바르지 않습니다. 다시 확인해주세요.";
+        } else if (failed instanceof DisabledException) {
+            errorMessage = "계정이 비활성화 되어있습니다. 이메일 인증을 완료해주세요";
+        }
+
+        return errorMessage;
     }
 }

--- a/src/main/java/org/store/clothstar/common/error/ErrorCode.java
+++ b/src/main/java/org/store/clothstar/common/error/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "refresh 토큰이 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh 토큰이 만료되었거나 유효하지 않습니다."),
-    ERROR_MAIL_SENDER(HttpStatus.BAD_REQUEST, "메일을 전송하는 도중 에러가 발생하였습니다.");
+    INVALID_AUTH_CERTIFY_NUM(HttpStatus.BAD_REQUEST, "인증번호가 잘못 되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/store/clothstar/common/error/ErrorCode.java
+++ b/src/main/java/org/store/clothstar/common/error/ErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "refresh 토큰이 없습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh 토큰이 만료되었거나 유효하지 않습니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "refresh 토큰이 만료되었거나 유효하지 않습니다."),
+    ERROR_MAIL_SENDER(HttpStatus.BAD_REQUEST, "메일을 전송하는 도중 에러가 발생하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/store/clothstar/common/error/exception/MailSenderErrorException.java
+++ b/src/main/java/org/store/clothstar/common/error/exception/MailSenderErrorException.java
@@ -1,0 +1,12 @@
+package org.store.clothstar.common.error.exception;
+
+import org.store.clothstar.common.error.ErrorCode;
+
+public class MailSenderErrorException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public MailSenderErrorException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/store/clothstar/common/error/exception/SignupCertifyNumAuthFailedException.java
+++ b/src/main/java/org/store/clothstar/common/error/exception/SignupCertifyNumAuthFailedException.java
@@ -2,10 +2,10 @@ package org.store.clothstar.common.error.exception;
 
 import org.store.clothstar.common.error.ErrorCode;
 
-public class MailSenderErrorException extends RuntimeException {
+public class SignupCertifyNumAuthFailedException extends RuntimeException {
     private final ErrorCode errorCode;
 
-    public MailSenderErrorException(ErrorCode errorCode) {
+    public SignupCertifyNumAuthFailedException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/src/main/java/org/store/clothstar/common/exception/ExceptionType.java
+++ b/src/main/java/org/store/clothstar/common/exception/ExceptionType.java
@@ -5,7 +5,5 @@ import org.springframework.http.HttpStatus;
 public interface ExceptionType {
     HttpStatus status();
 
-    int exceptionCode();
-
     String message();
 }

--- a/src/main/java/org/store/clothstar/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/store/clothstar/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package org.store.clothstar.common.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mail.MailException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -33,6 +34,16 @@ public class GlobalExceptionHandler {
         ValidErrorResponseDTO validErrorResponseDTO = new ValidErrorResponseDTO(HttpStatus.BAD_REQUEST.value(), errorMap);
 
         return new ResponseEntity<>(validErrorResponseDTO, HttpStatus.BAD_REQUEST);
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler
+    private ResponseEntity<ErrorResponseDTO> mailException(MailException ex) {
+        log.error("[MailException Handler] {}", ex.getMessage());
+        ex.fillInStackTrace();
+        ErrorResponseDTO errorResponseDTO = new ErrorResponseDTO(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
+
+        return new ResponseEntity<>(errorResponseDTO, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/org/store/clothstar/common/mail/MailContentBuilder.java
+++ b/src/main/java/org/store/clothstar/common/mail/MailContentBuilder.java
@@ -11,9 +11,9 @@ import org.thymeleaf.context.Context;
 public class MailContentBuilder {
     private final TemplateEngine templateEngine;
 
-    public String build(String message) {
+    public String build(String certifyNum) {
         Context context = new Context();
-        context.setVariable("link", message);
+        context.setVariable("certifyNum", certifyNum);
         return templateEngine.process("mailTemplate", context);
     }
 }

--- a/src/main/java/org/store/clothstar/common/mail/MailContentBuilder.java
+++ b/src/main/java/org/store/clothstar/common/mail/MailContentBuilder.java
@@ -1,0 +1,19 @@
+package org.store.clothstar.common.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+
+@Service
+@RequiredArgsConstructor
+public class MailContentBuilder {
+    private final TemplateEngine templateEngine;
+
+    public String build(String message) {
+        Context context = new Context();
+        context.setVariable("link", message);
+        return templateEngine.process("mailTemplate", context);
+    }
+}

--- a/src/main/java/org/store/clothstar/common/mail/MailSendDTO.java
+++ b/src/main/java/org/store/clothstar/common/mail/MailSendDTO.java
@@ -1,0 +1,14 @@
+package org.store.clothstar.common.mail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MailSendDTO {
+    private String address;
+    private String subject;
+    private String text;
+}

--- a/src/main/java/org/store/clothstar/common/mail/MailService.java
+++ b/src/main/java/org/store/clothstar/common/mail/MailService.java
@@ -25,8 +25,8 @@ public class MailService {
             messageHelper.setSubject(mailSendDTO.getSubject());
             messageHelper.setText(mailSendDTO.getText(), true);
         };
-        log.error("전송 메일주소 : {} -> {}", fromAddress, mailSendDTO.getAddress());
 
+        log.info("전송 메일주소 : {} -> {}", fromAddress, mailSendDTO.getAddress());
         mailSender.send(messagePreparator);
 
         return true;

--- a/src/main/java/org/store/clothstar/common/mail/MailService.java
+++ b/src/main/java/org/store/clothstar/common/mail/MailService.java
@@ -1,0 +1,34 @@
+package org.store.clothstar.common.mail;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MailService {
+    private final JavaMailSender mailSender;
+
+    @Value("${email.send}")
+    private String fromAddress;
+
+    public boolean sendMail(MailSendDTO mailSendDTO) {
+        MimeMessagePreparator messagePreparator = mimeMessage -> {
+            MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+            messageHelper.setFrom(fromAddress);
+            messageHelper.setTo(mailSendDTO.getAddress());
+            messageHelper.setSubject(mailSendDTO.getSubject());
+            messageHelper.setText(mailSendDTO.getText(), true);
+        };
+        log.error("전송 메일주소 : {} -> {}", fromAddress, mailSendDTO.getAddress());
+
+        mailSender.send(messagePreparator);
+
+        return true;
+    }
+}

--- a/src/main/java/org/store/clothstar/common/redis/RedisConfig.java
+++ b/src/main/java/org/store/clothstar/common/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package org.store.clothstar.common.config;
+package org.store.clothstar.common.redis;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/org/store/clothstar/common/redis/RedisUtil.java
+++ b/src/main/java/org/store/clothstar/common/redis/RedisUtil.java
@@ -1,0 +1,34 @@
+package org.store.clothstar.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+    private final StringRedisTemplate template;
+
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(template.hasKey(key));
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        template.delete(key);
+    }
+
+}

--- a/src/main/java/org/store/clothstar/common/redis/RedisUtil.java
+++ b/src/main/java/org/store/clothstar/common/redis/RedisUtil.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Random;
 
 @RequiredArgsConstructor
 @Service
@@ -33,5 +34,26 @@ public class RedisUtil {
 
     public void deleteData(String key) {
         template.delete(key);
+    }
+
+    public void createRedisData(String toEmail, String code) {
+        if (existData(toEmail)) {
+            deleteData(toEmail);
+        }
+
+        setDataExpire(toEmail, code);
+    }
+
+    public String createdCertifyNum() {
+        int leftLimit = 48; // number '0'
+        int rightLimit = 122; // alphabet 'z'
+        int targetStringLength = 6;
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
     }
 }

--- a/src/main/java/org/store/clothstar/common/redis/RedisUtil.java
+++ b/src/main/java/org/store/clothstar/common/redis/RedisUtil.java
@@ -1,6 +1,7 @@
 package org.store.clothstar.common.redis;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,9 @@ import java.time.Duration;
 public class RedisUtil {
     private final StringRedisTemplate template;
 
+    @Value("${spring.data.redis.duration}")
+    private int duration;
+
     public String getData(String key) {
         ValueOperations<String, String> valueOperations = template.opsForValue();
         return valueOperations.get(key);
@@ -21,7 +25,7 @@ public class RedisUtil {
         return Boolean.TRUE.equals(template.hasKey(key));
     }
 
-    public void setDataExpire(String key, String value, long duration) {
+    public void setDataExpire(String key, String value) {
         ValueOperations<String, String> valueOperations = template.opsForValue();
         Duration expireDuration = Duration.ofSeconds(duration);
         valueOperations.set(key, value, expireDuration);
@@ -30,5 +34,4 @@ public class RedisUtil {
     public void deleteData(String key) {
         template.delete(key);
     }
-
 }

--- a/src/main/java/org/store/clothstar/member/application/MemberServiceApplication.java
+++ b/src/main/java/org/store/clothstar/member/application/MemberServiceApplication.java
@@ -46,7 +46,7 @@ public class MemberServiceApplication {
         return memberService.signUp(createMemberDTO);
     }
 
-    public void signupEmailAuthentication(Long memberId) {
-        memberService.signupEmailAuthentication(memberId);
+    public void signupCertifyNumEmailSend(String email) {
+        memberService.signupCertifyNumEmailSend(email);
     }
 }

--- a/src/main/java/org/store/clothstar/member/application/MemberServiceApplication.java
+++ b/src/main/java/org/store/clothstar/member/application/MemberServiceApplication.java
@@ -45,4 +45,8 @@ public class MemberServiceApplication {
     public Long signup(CreateMemberRequest createMemberDTO) {
         return memberService.signUp(createMemberDTO);
     }
+
+    public void signupEmailAuthentication(Long memberId) {
+        memberService.signupEmailAuthentication(memberId);
+    }
 }

--- a/src/main/java/org/store/clothstar/member/controller/AuthenticationController.java
+++ b/src/main/java/org/store/clothstar/member/controller/AuthenticationController.java
@@ -6,23 +6,24 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.store.clothstar.common.dto.SaveResponseDTO;
 import org.store.clothstar.member.application.MemberServiceApplication;
+import org.store.clothstar.member.dto.request.CertifyNumRequest;
 import org.store.clothstar.member.dto.request.CreateMemberRequest;
 import org.store.clothstar.member.dto.request.MemberLoginRequest;
 
 @Tag(name = "Auth", description = "회원가입과 인증에 관한 API 입니다.")
-@Controller
+@RestController
 @RequiredArgsConstructor
 @Slf4j
 public class AuthenticationController {
     private final MemberServiceApplication memberServiceApplication;
 
     @Operation(summary = "회원가입", description = "회원가입시 회원 정보를 저장한다.")
-    @ResponseBody
     @PostMapping("/v1/members")
     public ResponseEntity<SaveResponseDTO> signup(@Validated @RequestBody CreateMemberRequest createMemberDTO) {
         log.info("회원가입 요청 데이터 : {}", createMemberDTO.toString());
@@ -45,9 +46,8 @@ public class AuthenticationController {
     }
 
     @Operation(summary = "이메일로 인증번호 전송", description = "기입한 이메일로 인증번호를 전송합니다.")
-    @ResponseBody
-    @GetMapping("/v1/members/auth/{email}")
-    public void signupEmailAuthentication(@PathVariable("email") String email) {
-        memberServiceApplication.signupCertifyNumEmailSend(email);
+    @PostMapping("/v1/members/auth")
+    public void signupEmailAuthentication(@Validated @RequestBody CertifyNumRequest certifyNumRequest) {
+        memberServiceApplication.signupCertifyNumEmailSend(certifyNumRequest.getEmail());
     }
 }

--- a/src/main/java/org/store/clothstar/member/controller/AuthenticationController.java
+++ b/src/main/java/org/store/clothstar/member/controller/AuthenticationController.java
@@ -32,7 +32,7 @@ public class AuthenticationController {
         SaveResponseDTO saveResponseDTO = SaveResponseDTO.builder()
                 .id(memberId)
                 .statusCode(HttpStatus.OK.value())
-                .message(createMemberDTO.getEmail() + " 계정으로 인증메일이 전송 되었습니다.")
+                .message(createMemberDTO.getEmail() + " 아이디로 회원가입이 완료 되었습니다.")
                 .build();
 
         return new ResponseEntity<>(saveResponseDTO, HttpStatus.CREATED);
@@ -44,10 +44,10 @@ public class AuthenticationController {
         // 실제 로그인 로직은 Spring Security에서 처리
     }
 
-    @Operation(summary = "회원가입시 이메일 인증", description = "회원가입후 전송된 이메일에 링크를 클릭하면 회원이 활성화 된다.")
-    @GetMapping("/v1/members/auth/{id}")
-    public String signupEmailAuthentication(@PathVariable("id") Long memberId) {
-        memberServiceApplication.signupEmailAuthentication(memberId);
-        return "redirect:/login";
+    @Operation(summary = "이메일로 인증번호 전송", description = "기입한 이메일로 인증번호를 전송합니다.")
+    @ResponseBody
+    @GetMapping("/v1/members/auth/{email}")
+    public void signupEmailAuthentication(@PathVariable("email") String email) {
+        memberServiceApplication.signupCertifyNumEmailSend(email);
     }
 }

--- a/src/main/java/org/store/clothstar/member/controller/AuthenticationController.java
+++ b/src/main/java/org/store/clothstar/member/controller/AuthenticationController.java
@@ -6,23 +6,23 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.store.clothstar.common.dto.SaveResponseDTO;
 import org.store.clothstar.member.application.MemberServiceApplication;
 import org.store.clothstar.member.dto.request.CreateMemberRequest;
 import org.store.clothstar.member.dto.request.MemberLoginRequest;
 
 @Tag(name = "Auth", description = "회원가입과 인증에 관한 API 입니다.")
-@RestController
+@Controller
 @RequiredArgsConstructor
 @Slf4j
 public class AuthenticationController {
     private final MemberServiceApplication memberServiceApplication;
 
     @Operation(summary = "회원가입", description = "회원가입시 회원 정보를 저장한다.")
+    @ResponseBody
     @PostMapping("/v1/members")
     public ResponseEntity<SaveResponseDTO> signup(@Validated @RequestBody CreateMemberRequest createMemberDTO) {
         log.info("회원가입 요청 데이터 : {}", createMemberDTO.toString());
@@ -32,7 +32,7 @@ public class AuthenticationController {
         SaveResponseDTO saveResponseDTO = SaveResponseDTO.builder()
                 .id(memberId)
                 .statusCode(HttpStatus.OK.value())
-                .message("memberId : " + memberId + " 가 정상적으로 회원가입 되었습니다.")
+                .message(createMemberDTO.getEmail() + " 계정으로 인증메일이 전송 되었습니다.")
                 .build();
 
         return new ResponseEntity<>(saveResponseDTO, HttpStatus.CREATED);
@@ -42,5 +42,12 @@ public class AuthenticationController {
     @PostMapping("/v1/members/login")
     public void login(@RequestBody MemberLoginRequest memberLoginRequest) {
         // 실제 로그인 로직은 Spring Security에서 처리
+    }
+
+    @Operation(summary = "회원가입시 이메일 인증", description = "회원가입후 전송된 이메일에 링크를 클릭하면 회원이 활성화 된다.")
+    @GetMapping("/v1/members/auth/{id}")
+    public String signupEmailAuthentication(@PathVariable("id") Long memberId) {
+        memberServiceApplication.signupEmailAuthentication(memberId);
+        return "redirect:/login";
     }
 }

--- a/src/main/java/org/store/clothstar/member/domain/CustomUserDetails.java
+++ b/src/main/java/org/store/clothstar/member/domain/CustomUserDetails.java
@@ -53,6 +53,6 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         //ture -> 계정 사용 가능
-        return true;
+        return memberEntity.isEnabled();
     }
 }

--- a/src/main/java/org/store/clothstar/member/domain/CustomUserDetails.java
+++ b/src/main/java/org/store/clothstar/member/domain/CustomUserDetails.java
@@ -53,6 +53,6 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         //ture -> 계정 사용 가능
-        return memberEntity.isEnabled();
+        return true;
     }
 }

--- a/src/main/java/org/store/clothstar/member/dto/request/CertifyNumRequest.java
+++ b/src/main/java/org/store/clothstar/member/dto/request/CertifyNumRequest.java
@@ -1,0 +1,14 @@
+package org.store.clothstar.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class CertifyNumRequest {
+    @NotNull(message = "이메일을 입력해 주세요")
+    private String email;
+}

--- a/src/main/java/org/store/clothstar/member/dto/request/CreateMemberRequest.java
+++ b/src/main/java/org/store/clothstar/member/dto/request/CreateMemberRequest.java
@@ -1,16 +1,10 @@
 package org.store.clothstar.member.dto.request;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.*;
-import org.store.clothstar.member.domain.Member;
 import org.store.clothstar.member.domain.MemberGrade;
 import org.store.clothstar.member.domain.MemberRole;
 import org.store.clothstar.member.entity.MemberEntity;
-
-import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -30,19 +24,8 @@ public class CreateMemberRequest {
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "유효하지 않은 전화번호 형식입니다.")
     private String telNo;
 
-    public Member toMember(String encryptedPassword) {
-        return Member.builder()
-                .email(email)
-                .password(encryptedPassword)
-                .name(name)
-                .telNo(telNo)
-                .totalPaymentPrice(0)
-                .point(0)
-                .role(MemberRole.USER)
-                .grade(MemberGrade.BRONZE)
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
+    @NotNull(message = "인증번호를 입력해 주세요")
+    private String certifyNum;
 
     public MemberEntity toMemberEntity(String encryptedPassword) {
         return MemberEntity.builder()

--- a/src/main/java/org/store/clothstar/member/dto/request/CreateMemberRequest.java
+++ b/src/main/java/org/store/clothstar/member/dto/request/CreateMemberRequest.java
@@ -39,4 +39,17 @@ public class CreateMemberRequest {
                 .grade(MemberGrade.BRONZE)
                 .build();
     }
+
+    public MemberEntity toMemberEntity() {
+        return MemberEntity.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .telNo(telNo)
+                .totalPaymentPrice(0)
+                .point(0)
+                .role(MemberRole.USER)
+                .grade(MemberGrade.BRONZE)
+                .build();
+    }
 }

--- a/src/main/java/org/store/clothstar/member/entity/MemberEntity.java
+++ b/src/main/java/org/store/clothstar/member/entity/MemberEntity.java
@@ -36,6 +36,7 @@ public class MemberEntity extends BaseEntity {
     private MemberRole role;
     @Enumerated(EnumType.STRING)
     private MemberGrade grade;
+    private boolean enabled;
 
     public MemberEntity(Member member) {
         this.memberId = member.getMemberId();
@@ -63,5 +64,9 @@ public class MemberEntity extends BaseEntity {
 
     public void updateDeletedAt() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void updateEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 }

--- a/src/main/java/org/store/clothstar/member/service/MemberService.java
+++ b/src/main/java/org/store/clothstar/member/service/MemberService.java
@@ -21,5 +21,5 @@ public interface MemberService {
 
     Long signUp(CreateMemberRequest createMemberDTO);
 
-    void signupEmailAuthentication(Long memberId);
+    void signupCertifyNumEmailSend(String email);
 }

--- a/src/main/java/org/store/clothstar/member/service/MemberService.java
+++ b/src/main/java/org/store/clothstar/member/service/MemberService.java
@@ -20,4 +20,6 @@ public interface MemberService {
     void modifyMember(Long memberId, ModifyMemberRequest modifyMemberRequest);
 
     Long signUp(CreateMemberRequest createMemberDTO);
+
+    void signupEmailAuthentication(Long memberId);
 }

--- a/src/main/java/org/store/clothstar/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/store/clothstar/member/service/MemberServiceImpl.java
@@ -1,6 +1,5 @@
 package org.store.clothstar.member.service;
 
-import jakarta.servlet.ServletContext;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +31,6 @@ public class MemberServiceImpl implements MemberService {
     private final PasswordEncoder passwordEncoder;
     private final MailContentBuilder mailContentBuilder;
     private final MailService mailService;
-    private final ServletContext context;
-
 
     @Override
     public List<MemberResponse> findAll() {

--- a/src/main/java/org/store/clothstar/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/store/clothstar/member/service/MemberServiceImpl.java
@@ -18,7 +18,6 @@ import org.store.clothstar.member.entity.MemberEntity;
 import org.store.clothstar.member.repository.MemberRepository;
 
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 /**
@@ -117,7 +116,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     private String sendEmailAuthentication(String toEmail) {
-        String certifyNum = createdCode();
+        String certifyNum = redisUtil.createdCertifyNum();
         String message = mailContentBuilder.build(certifyNum);
         MailSendDTO mailSendDTO = new MailSendDTO(toEmail, "clothstar 회원가입 인증 메일 입니다.", message);
 
@@ -125,7 +124,7 @@ public class MemberServiceImpl implements MemberService {
 
         //메일 전송에 성공하면 redis에 key = email, value = 인증번호를 생성한다.
         //지속시간은 10분
-        createRedis(toEmail, certifyNum);
+        redisUtil.createRedisData(toEmail, certifyNum);
 
         return certifyNum;
     }
@@ -137,26 +136,5 @@ public class MemberServiceImpl implements MemberService {
         }
 
         return codeFoundByEmail.equals(certifyNum);
-    }
-
-    private void createRedis(String toEmail, String code) {
-        if (redisUtil.existData(toEmail)) {
-            redisUtil.deleteData(toEmail);
-        }
-
-        redisUtil.setDataExpire(toEmail, code);
-    }
-
-    private String createdCode() {
-        int leftLimit = 48; // number '0'
-        int rightLimit = 122; // alphabet 'z'
-        int targetStringLength = 6;
-        Random random = new Random();
-
-        return random.ints(leftLimit, rightLimit + 1)
-                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
-                .limit(targetStringLength)
-                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-                .toString();
     }
 }

--- a/src/main/java/org/store/clothstar/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/store/clothstar/member/service/MemberServiceImpl.java
@@ -99,7 +99,7 @@ public class MemberServiceImpl implements MemberService {
         MemberEntity memberEntity = createMemberDTO.toMemberEntity(encodedPassword);
 
         //인증코드 확인
-        boolean certifyStatus = verifyEmailCode(memberEntity.getEmail(), createMemberDTO.getCertifyNum());
+        boolean certifyStatus = verifyEmailCertifyNum(memberEntity.getEmail(), createMemberDTO.getCertifyNum());
         if (certifyStatus) {
             memberEntity = memberRepository.save(memberEntity);
         } else {
@@ -129,12 +129,12 @@ public class MemberServiceImpl implements MemberService {
         return certifyNum;
     }
 
-    public Boolean verifyEmailCode(String email, String certifyNum) {
-        String codeFoundByEmail = redisUtil.getData(email);
-        if (codeFoundByEmail == null) {
+    public Boolean verifyEmailCertifyNum(String email, String certifyNum) {
+        String certifyNumFoundByRedis = redisUtil.getData(email);
+        if (certifyNumFoundByRedis == null) {
             return false;
         }
 
-        return codeFoundByEmail.equals(certifyNum);
+        return certifyNumFoundByRedis.equals(certifyNum);
     }
 }

--- a/src/main/java/org/store/clothstar/product/entity/ProductEntity.java
+++ b/src/main/java/org/store/clothstar/product/entity/ProductEntity.java
@@ -50,6 +50,7 @@ public class ProductEntity {
         checkAndUpdateProductLineStatus();
     }
 
+    //  재고를 차감하고 상태를 변경하는 메서드
     public void reduceStock(int quantity) {
         if (this.stock >= quantity) {
             this.stock -= quantity;
@@ -59,6 +60,7 @@ public class ProductEntity {
         }
     }
 
+    // 재고 변경 시 ProductLine 상태 업데이트 메서드
     private void checkAndUpdateProductLineStatus() {
         if (productLine != null) {
             productLine.checkAndUpdateStatus();

--- a/src/main/java/org/store/clothstar/productLine/exception/ProductLineExceptionType.java
+++ b/src/main/java/org/store/clothstar/productLine/exception/ProductLineExceptionType.java
@@ -17,7 +17,6 @@ public enum ProductLineExceptionType implements ExceptionType {
         return status;
     }
 
-    @Override
     public int exceptionCode() {
         return exceptionCode;
     }

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -49,9 +49,7 @@ spring:
 
 
 --- # dev 공통 설정
-jasypt:
-  encryptor:
-    bean: jasyptStringEncryptor
+
 
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
           auth: true
           starttls:
             enable: true
+  # Redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 email.send: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      duration: 600
 
 email.send: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+jasypt:
+  encryptor:
+    bean: jasyptStringEncryptor
+
 spring:
   profiles:
     active:
@@ -9,6 +13,17 @@ spring:
         - db-dev
     include:
       - db
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)
+    password: ENC(/hOuHdVpOgyzKrlqyayORlsTFpIrwe7RYnfAqXEFzIk=)
+    properties:
+      mail.smtp:
+        auth: true
+        enable: true
+
+email.send: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)
 
 springdoc:
   default-consumes-media-type: application/json # 소비 미디어 타입

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,9 +19,11 @@ spring:
     username: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)
     password: ENC(/hOuHdVpOgyzKrlqyayORlsTFpIrwe7RYnfAqXEFzIk=)
     properties:
-      mail.smtp:
-        auth: true
-        enable: true
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 email.send: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
   # Redis
   data:
     redis:
-      host: localhost
+      host: ENC(GUuFDW7HjE98e7N28Vkb/xoIEgLeOCb5)
       port: 6379
       duration: 600
 

--- a/src/main/resources/sql/member.sql
+++ b/src/main/resources/sql/member.sql
@@ -12,6 +12,7 @@ CREATE TABLE `member`
     `created_at`          timestamp    NOT NULL,
     `modified_at`         timestamp    NULL,
     `deleted_at`          timestamp    NULL,
+    `enabled`             boolean      NOT NULL DEFAULT FALSE,
 
     CONSTRAINT PK_member PRIMARY KEY (member_id),
     CONSTRAINT UK_member_email UNIQUE (email)
@@ -71,7 +72,7 @@ from seller;
 select *
 from productLine;
 select *
-from member;
+from member where email = 'rkdgustn@test.com';
 
 select *
 from information_schema.table_constraints
@@ -110,3 +111,5 @@ from seller;
 
 alter table member
     change modified_at updated_at timestamp;
+
+ALTER TABLE member ADD COLUMN enabled boolean not null default false;

--- a/src/main/resources/static/js/signup.js
+++ b/src/main/resources/static/js/signup.js
@@ -1,4 +1,27 @@
 const createButton = document.getElementById("create-btn");
+const certifyNumEmailSendButton = document.getElementById("certifyNum-btn");
+
+if (certifyNumEmailSendButton) {
+    certifyNumEmailSendButton.addEventListener("click", (event) => {
+        const emailValue = document.getElementById("email").value;
+        if (emailValue == null || emailValue == "") {
+            alert("이메일을 입력해 주세요");
+        } else {
+            fetch(`/v1/members/auth/${emailValue}`, {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            }).then((res) => {
+                if (res.ok) {
+                    alert("인증번호가 전송 되었습니다.")
+                }
+            }).catch(() => {
+                console.log("catch");
+            });
+        }
+    });
+}
 
 if (createButton) {
     createButton.addEventListener("click", (event) => {
@@ -12,6 +35,7 @@ if (createButton) {
                 password: document.getElementById("password").value,
                 name: document.getElementById("name").value,
                 telNo: document.getElementById("telNo").value,
+                certifyNum: document.getElementById("certifyNum").value,
             }),
         }).then((res) => res.json())
             .then((res) => {
@@ -24,7 +48,7 @@ if (createButton) {
             }).catch(() => {
             alert("ajax 호출 에러")
         });
-    })
+    });
 }
 
 const emailCheck = () => {

--- a/src/main/resources/static/js/signup.js
+++ b/src/main/resources/static/js/signup.js
@@ -7,11 +7,14 @@ if (certifyNumEmailSendButton) {
         if (emailValue == null || emailValue == "") {
             alert("이메일을 입력해 주세요");
         } else {
-            fetch(`/v1/members/auth/${emailValue}`, {
-                method: "GET",
+            fetch(`/v1/members/auth`, {
+                method: "POST",
                 headers: {
                     "Content-Type": "application/json",
                 },
+                body: JSON.stringify({
+                    email: emailValue
+                }),
             }).then((res) => {
                 if (res.ok) {
                     alert("인증번호가 전송 되었습니다.")

--- a/src/main/resources/templates/mailTemplate.html
+++ b/src/main/resources/templates/mailTemplate.html
@@ -1,10 +1,16 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>이메일 인증 링크</title>
-</head>
+<html xmlns:th="http://www.thymeleaf.org">
 <body>
-<span>계정 활성화를 위해서 아래의 인증 링크를 클릭해주세요.</span><br>
-<a th:href="${link}">인증 링크</a>
+<div style="margin:120px">
+    <div style="margin-bottom: 10px">
+        <h1>인증 코드 메일입니다.</h1>
+        <br/>
+        <h3 style="text-align: center;"> 아래 코드를 사이트에 입력해주십시오</h3>
+    </div>
+    <div style="text-align: center;">
+        <h2 style="color: crimson;" th:text="${code}"></h2>
+    </div>
+    <br/>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/mailTemplate.html
+++ b/src/main/resources/templates/mailTemplate.html
@@ -5,10 +5,10 @@
     <div style="margin-bottom: 10px">
         <h1>인증 코드 메일입니다.</h1>
         <br/>
-        <h3 style="text-align: center;"> 아래 코드를 사이트에 입력해주십시오</h3>
+        <h3> 아래 코드를 사이트에 입력해주십시오</h3>
     </div>
-    <div style="text-align: center;">
-        <h2 style="color: crimson;" th:text="${code}"></h2>
+    <div>
+        <h2 style="color: crimson;" th:text="${certifyNum}"></h2>
     </div>
     <br/>
 </div>

--- a/src/main/resources/templates/mailTemplate.html
+++ b/src/main/resources/templates/mailTemplate.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>이메일 인증 링크</title>
+</head>
+<body>
+<span>계정 활성화를 위해서 아래의 인증 링크를 클릭해주세요.</span><br>
+<a th:href="${link}">인증 링크</a>
+</body>
+</html>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -38,6 +38,13 @@
                         <label class="form-label text-white">tel no</label>
                         <input type="telNo" id="telNo" class="form-control" name="telNo">
                     </div>
+                    <div class="mb-3">
+                        <label class="form-label text-white">인증 번호</label>
+                        <div class="input-group">
+                            <input type="certifyNum" id="certifyNum" class="form-control" name="certifyNum">
+                            <button id="certifyNum-btn" class="btn btn-success">인증 번호 전송</button>
+                        </div>
+                    </div>
 
                     <button id="create-btn" class="btn btn-primary">Submit</button>
                 </div>

--- a/src/test/java/org/store/clothstar/common/config/JasyptConfigTest.java
+++ b/src/test/java/org/store/clothstar/common/config/JasyptConfigTest.java
@@ -10,9 +10,9 @@ class JasyptConfigTest {
     @Test
     void jasypt() {
         String url = "";
-        String username = "";
-        String password = "";
-        
+        String username = "nexthope22@gmail.com";
+        String password = "pcde pppv pnxa dfmg";
+
         System.out.println(jasyptEncoding(url));
         System.out.println(jasyptEncoding(username));
         System.out.println(jasyptEncoding(password));

--- a/src/test/java/org/store/clothstar/common/config/JasyptConfigTest.java
+++ b/src/test/java/org/store/clothstar/common/config/JasyptConfigTest.java
@@ -10,8 +10,8 @@ class JasyptConfigTest {
     @Test
     void jasypt() {
         String url = "";
-        String username = "nexthope22@gmail.com";
-        String password = "pcde pppv pnxa dfmg";
+        String username = "";
+        String password = "";
 
         System.out.println(jasyptEncoding(url));
         System.out.println(jasyptEncoding(username));

--- a/src/test/java/org/store/clothstar/common/config/jwt/JwtControllerIntegrationTest.java
+++ b/src/test/java/org/store/clothstar/common/config/jwt/JwtControllerIntegrationTest.java
@@ -11,10 +11,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
-import org.store.clothstar.member.dto.request.CreateMemberRequest;
 import org.store.clothstar.member.entity.MemberEntity;
 import org.store.clothstar.member.repository.MemberRepository;
-import org.store.clothstar.member.service.MemberService;
+import org.store.clothstar.member.util.CreateObject;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -28,28 +27,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 class JwtControllerIntegrationTest {
     @Autowired
-    private JwtController jwtController;
-
-    @Autowired
     private JwtUtil jwtUtil;
 
     @Autowired
     private MockMvc mockMvc;
 
     @Autowired
-    private MemberService memberService;
-
-    @Autowired
     private MemberRepository memberRepository;
 
-    private Long memberId;
     private MemberEntity memberEntity;
 
     @DisplayName("회원가입한 멤버아이디와, 인증에 필요한 access 토큰을 가져옵니다.")
     @BeforeEach
     public void getMemberId_getAccessToken() {
-        memberId = memberService.signUp(getCreateMemberRequest());
-        memberEntity = memberRepository.findById(memberId).get();
+        memberEntity = memberRepository.save(CreateObject.getMemberEntityByCreateMemberRequestDTO());
     }
 
     @DisplayName("refresh 토큰으로 access 토큰을 가져온다.")
@@ -68,18 +59,5 @@ class JwtControllerIntegrationTest {
         actions.andExpect(status().isOk());
         actions.andDo(print());
         actions.andExpect(jsonPath("$.accessToken").isNotEmpty());
-    }
-
-    private CreateMemberRequest getCreateMemberRequest() {
-        String email = "test11@naver.com";
-        String password = "testl122sff";
-        String name = "name";
-        String telNo = "010-1234-1245";
-
-        CreateMemberRequest createMemberRequest = new CreateMemberRequest(
-                email, password, name, telNo
-        );
-
-        return createMemberRequest;
     }
 }

--- a/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
+++ b/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
@@ -1,7 +1,6 @@
 package org.store.clothstar.common.mail;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +9,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Disabled
 class MailServiceTest {
     @Autowired
     MailService mailService;

--- a/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
+++ b/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
@@ -1,0 +1,33 @@
+package org.store.clothstar.common.mail;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MailServiceTest {
+    @Autowired
+    MailService mailService;
+    @Autowired
+    MailContentBuilder mailContentBuilder;
+
+    @DisplayName("메일 전송 테스트")
+    @Test
+    void mailSendTest() {
+        //given
+//        String link = Constants.ACTIVATION_EMAIL + "/" + token;
+        String link = "https://www.naver.com/";
+        String message = mailContentBuilder.build(link);
+        MailSendDTO mailSendDTO = new MailSendDTO("", "test", message);
+
+        //when
+        Boolean success = mailService.sendMail(mailSendDTO);
+
+        //then
+        Assertions.assertThat(success).isTrue();
+    }
+}

--- a/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
+++ b/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
@@ -22,7 +22,7 @@ class MailServiceTest {
 //        String link = Constants.ACTIVATION_EMAIL + "/" + token;
         String link = "https://www.naver.com/";
         String message = mailContentBuilder.build(link);
-        MailSendDTO mailSendDTO = new MailSendDTO("", "test", message);
+        MailSendDTO mailSendDTO = new MailSendDTO("test@test.com", "test", message);
 
         //when
         Boolean success = mailService.sendMail(mailSendDTO);

--- a/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
+++ b/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
@@ -1,6 +1,7 @@
 package org.store.clothstar.common.mail;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Disabled
 class MailServiceTest {
     @Autowired
     MailService mailService;

--- a/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
+++ b/src/test/java/org/store/clothstar/common/mail/MailServiceTest.java
@@ -19,7 +19,6 @@ class MailServiceTest {
     @Test
     void mailSendTest() {
         //given
-//        String link = Constants.ACTIVATION_EMAIL + "/" + token;
         String link = "https://www.naver.com/";
         String message = mailContentBuilder.build(link);
         MailSendDTO mailSendDTO = new MailSendDTO("test@test.com", "test", message);

--- a/src/test/java/org/store/clothstar/common/redis/RedisUtilTest.java
+++ b/src/test/java/org/store/clothstar/common/redis/RedisUtilTest.java
@@ -1,29 +1,39 @@
 package org.store.clothstar.common.redis;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class RedisUtilTest {
 
     @Autowired
     private RedisUtil redisUtil;
 
-
+    @DisplayName("redis 데이터가 생성되고 삭제되는지 확인한다.")
     @Test
-    public void redisTest() throws Exception {
+    public void redisCreateAndDeleteTest() throws Exception {
+        //redis 데이터가 생성됐는지 확인한다.
         //given
-        String email = "test@test.com";
-        String code = "aaa111";
+        String key = "test@test.com";
+        String value = "aaa111";
 
         //when
-        redisUtil.setDataExpire(email, code);
+        redisUtil.setDataExpire(key, value);
 
         //then
-        Assertions.assertTrue(redisUtil.existData("test@test.com"));
-        Assertions.assertFalse(redisUtil.existData("test1@test.com"));
-        Assertions.assertEquals(redisUtil.getData(email), "aaa111");
+        Assertions.assertTrue(redisUtil.existData(key));
+        Assertions.assertEquals(redisUtil.getData(key), value);
+
+        //redis 데이터가 삭제 됐는지 확인한다.
+        //when
+        redisUtil.deleteData(key);
+
+        //then
+        Assertions.assertFalse(redisUtil.existData(key));
     }
 }

--- a/src/test/java/org/store/clothstar/common/redis/RedisUtilTest.java
+++ b/src/test/java/org/store/clothstar/common/redis/RedisUtilTest.java
@@ -1,0 +1,29 @@
+package org.store.clothstar.common.redis;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class RedisUtilTest {
+
+    @Autowired
+    private RedisUtil redisUtil;
+
+
+    @Test
+    public void redisTest() throws Exception {
+        //given
+        String email = "test@test.com";
+        String code = "aaa111";
+
+        //when
+        redisUtil.setDataExpire(email, code);
+
+        //then
+        Assertions.assertTrue(redisUtil.existData("test@test.com"));
+        Assertions.assertFalse(redisUtil.existData("test1@test.com"));
+        Assertions.assertEquals(redisUtil.getData(email), "aaa111");
+    }
+}

--- a/src/test/java/org/store/clothstar/member/controller/AddressControllerIntegrationTest.java
+++ b/src/test/java/org/store/clothstar/member/controller/AddressControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import org.store.clothstar.member.repository.AddressRepository;
 import org.store.clothstar.member.repository.MemberRepository;
 import org.store.clothstar.member.service.AddressServiceImpl;
 import org.store.clothstar.member.service.MemberService;
+import org.store.clothstar.member.util.CreateObject;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -58,16 +59,17 @@ class AddressControllerIntegrationTest {
     private JwtUtil jwtUtil;
 
     private static final String ADDRESS_URL = "/v1/members/addresses/";
+
+    private MemberEntity memberEntity;
     private Long memberId;
     private String accessToken;
-    private MemberEntity member;
 
     @DisplayName("회원가입한 멤버아이디와, 인증에 필요한 access 토큰을 가져옵니다.")
     @BeforeEach
     public void getMemberId_getAccessToken() {
-        memberId = memberService.signUp(getCreateMemberRequest());
-        member = memberRepository.findById(memberId).get();
-        accessToken = jwtUtil.createAccessToken(member);
+        memberEntity = memberRepository.save(CreateObject.getMemberEntityByCreateMemberRequestDTO());
+        memberId = memberEntity.getMemberId();
+        accessToken = jwtUtil.createAccessToken(memberEntity);
     }
 
     @DisplayName("회원 배송지 저장 통합 테스트")
@@ -155,9 +157,10 @@ class AddressControllerIntegrationTest {
         String password = "testl122sff";
         String name = "name";
         String telNo = "010-1234-1245";
+        String certifyNum = "123asdf";
 
         CreateMemberRequest createMemberRequest = new CreateMemberRequest(
-                email, password, name, telNo
+                email, password, name, telNo, certifyNum
         );
 
         return createMemberRequest;

--- a/src/test/java/org/store/clothstar/member/controller/MemberControllerValidationTest.java
+++ b/src/test/java/org/store/clothstar/member/controller/MemberControllerValidationTest.java
@@ -13,10 +13,14 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+import org.store.clothstar.common.error.exception.SignupCertifyNumAuthFailedException;
 import org.store.clothstar.member.dto.request.CreateMemberRequest;
 import org.store.clothstar.member.dto.request.ModifyPasswordRequest;
 import org.store.clothstar.member.repository.MemberRepository;
+import org.store.clothstar.member.service.MemberService;
+import org.store.clothstar.member.util.CreateObject;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -36,9 +40,24 @@ public class MemberControllerValidationTest {
     @Autowired
     MemberRepository memberRepository;
 
+    @Autowired
+    MemberService memberService;
+
     private static final String MEMBER_SIGN_UP_URL = "/v1/members";
 
-    @DisplayName("회원가입시 이메일 양식을 지켜야 한다..")
+    @DisplayName("회원가입시 인증번호가 틀리면 회원가입이 안돼야 한다.")
+    @Test
+    void signUpCertifyNumFailTest() {
+        //given
+        CreateMemberRequest createMemberRequest = CreateObject.getCreateMemberRequest();
+
+        //when & then
+        Throwable exception = assertThrows(SignupCertifyNumAuthFailedException.class, () -> {
+            memberService.signUp(createMemberRequest);
+        });
+    }
+
+    @DisplayName("회원가입시 이메일 양식을 지켜야 한다.")
     @Test
     void signUp_emailValidationTest() throws Exception {
         //given

--- a/src/test/java/org/store/clothstar/member/controller/SellerControllerIntegrationTest.java
+++ b/src/test/java/org/store/clothstar/member/controller/SellerControllerIntegrationTest.java
@@ -13,8 +13,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.store.clothstar.member.dto.request.CreateMemberRequest;
 import org.store.clothstar.member.dto.request.CreateSellerRequest;
+import org.store.clothstar.member.entity.MemberEntity;
+import org.store.clothstar.member.repository.MemberRepository;
 import org.store.clothstar.member.service.MemberServiceImpl;
 import org.store.clothstar.member.service.SellerServiceImpl;
+import org.store.clothstar.member.util.CreateObject;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -32,10 +35,14 @@ class SellerControllerIntegrationTest {
     private SellerServiceImpl sellerServiceImpl;
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     MemberServiceImpl memberServiceImpl;
 
     private static final String SELLER_URL = "/v1/sellers";
 
+    MemberEntity memberEntity;
     private Long memberId;
     private final String brandName = "나이키";
     private final String bizNo = "102-13-13122";
@@ -45,7 +52,8 @@ class SellerControllerIntegrationTest {
     @Test
     void getSellerTest() throws Exception {
         //given
-        memberId = memberServiceImpl.signUp(getCreateMemberRequest("test1@naver.com"));
+        memberEntity = memberRepository.save(CreateObject.getMemberEntityByCreateMemberRequestDTO());
+        memberId = memberEntity.getMemberId();
         Long sellerId = sellerServiceImpl.sellerSave(memberId, getCreateSellerRequest());
         String sellerMemberIdURL = SELLER_URL + "/" + memberId;
 
@@ -65,9 +73,10 @@ class SellerControllerIntegrationTest {
         String password = "test1234";
         String name = "현수";
         String telNo = "010-1234-1244";
+        String certifyNum = "123asdf";
 
         CreateMemberRequest createMemberRequest = new CreateMemberRequest(
-                email, password, name, telNo
+                email, password, name, telNo, certifyNum
         );
 
         return createMemberRequest;

--- a/src/test/java/org/store/clothstar/member/service/MemberServiceJpaUnitTest.java
+++ b/src/test/java/org/store/clothstar/member/service/MemberServiceJpaUnitTest.java
@@ -8,10 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.store.clothstar.member.domain.MemberRole;
-import org.store.clothstar.member.dto.request.CreateMemberRequest;
 import org.store.clothstar.member.dto.request.ModifyMemberRequest;
 import org.store.clothstar.member.entity.MemberEntity;
 import org.store.clothstar.member.repository.MemberRepository;
+import org.store.clothstar.member.util.CreateObject;
 
 import java.time.LocalDateTime;
 
@@ -35,9 +35,9 @@ public class MemberServiceJpaUnitTest {
     @BeforeEach
     public void getMemberId_getAccessToken() {
         //given && when
-        memberId = memberServiceImpl.signUp(getCreateMemberRequest());
-        memberEntity = memberRepository.findById(memberId).get();
-
+        memberEntity = memberRepository.save(CreateObject.getMemberEntityByCreateMemberRequestDTO());
+        memberId = memberEntity.getMemberId();
+        
         //then
         assertThat(memberId).isNotNull();
     }
@@ -116,22 +116,11 @@ public class MemberServiceJpaUnitTest {
     @Test
     void signUpValid_idDuplicateCheck() {
         Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-            memberServiceImpl.signUp(getCreateMemberRequest());
+            memberServiceImpl.signUp(CreateObject.getCreateMemberRequest());
         });
 
         assertThat(exception.getMessage()).isEqualTo("이미 존재하는 아이디 입니다.");
     }
 
-    private CreateMemberRequest getCreateMemberRequest() {
-        String email = "test3@test.com";
-        String password = "testl122";
-        String name = "현수";
-        String telNo = "010-1234-1245";
 
-        CreateMemberRequest createMemberRequest = new CreateMemberRequest(
-                email, password, name, telNo
-        );
-
-        return createMemberRequest;
-    }
 }

--- a/src/test/java/org/store/clothstar/member/service/SellerCreateJpaServiceUnitTest.java
+++ b/src/test/java/org/store/clothstar/member/service/SellerCreateJpaServiceUnitTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.store.clothstar.member.dto.request.CreateMemberRequest;
 import org.store.clothstar.member.dto.request.CreateSellerRequest;
+import org.store.clothstar.member.entity.MemberEntity;
+import org.store.clothstar.member.repository.MemberRepository;
+import org.store.clothstar.member.util.CreateObject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -23,6 +25,10 @@ class SellerCreateJpaServiceUnitTest {
     @Autowired
     private MemberService memberService;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private MemberEntity memberEntity;
     private Long memberId;
     private Long memberId2;
     private String brandName = "나이키";
@@ -31,8 +37,11 @@ class SellerCreateJpaServiceUnitTest {
     @DisplayName("회원가입과 판매자 신청을 진행 하고 memberId와 sellerId가 정상적으로 반환되는지 확인한다.")
     @BeforeEach
     public void signUp_getMemberId() {
-        memberId = memberService.signUp(getCreateMemberRequest());
-        memberId2 = memberService.signUp(getCreateMemberRequest2());
+        memberEntity = memberRepository.save(CreateObject.getCreateMemberRequest("test1@naver.com").toMemberEntity());
+        memberId = memberEntity.getMemberId();
+
+        memberEntity = memberRepository.save(CreateObject.getCreateMemberRequest("test2@naver.com").toMemberEntity());
+        memberId2 = memberEntity.getMemberId();
 
         Long sellerId = sellerService.sellerSave(memberId, getCreateSellerRequest());
 
@@ -87,31 +96,6 @@ class SellerCreateJpaServiceUnitTest {
         assertThat(exception.getMessage()).isEqualTo("이미 존재하는 사업자 번호 입니다.");
     }
 
-    private CreateMemberRequest getCreateMemberRequest() {
-        String email = "test@test.com";
-        String password = "testl122";
-        String name = "현수";
-        String telNo = "010-1234-1245";
-
-        CreateMemberRequest createMemberRequest = new CreateMemberRequest(
-                email, password, name, telNo
-        );
-
-        return createMemberRequest;
-    }
-
-    private CreateMemberRequest getCreateMemberRequest2() {
-        String email = "test2@test.com";
-        String password = "testl122";
-        String name = "현수";
-        String telNo = "010-1234-1245";
-
-        CreateMemberRequest createMemberRequest = new CreateMemberRequest(
-                email, password, name, telNo
-        );
-
-        return createMemberRequest;
-    }
 
     private CreateSellerRequest getCreateSellerRequest() {
         CreateSellerRequest createSellerRequest = new CreateSellerRequest(

--- a/src/test/java/org/store/clothstar/member/util/CreateObject.java
+++ b/src/test/java/org/store/clothstar/member/util/CreateObject.java
@@ -31,6 +31,17 @@ public class CreateObject {
         return createMemberRequest;
     }
 
+    public static CreateMemberRequest getCreateMemberRequest(String email, String certifyNum) {
+        String password = "testl122";
+        String name = "현수";
+        String telNo = "010-1234-1245";
+
+        CreateMemberRequest createMemberRequest = new CreateMemberRequest(
+                email, password, name, telNo, certifyNum
+        );
+
+        return createMemberRequest;
+    }
 
     public static MemberEntity getMemberEntityByCreateMemberRequestDTO() {
         return getCreateMemberRequest().toMemberEntity();

--- a/src/test/java/org/store/clothstar/member/util/CreateObject.java
+++ b/src/test/java/org/store/clothstar/member/util/CreateObject.java
@@ -1,0 +1,38 @@
+package org.store.clothstar.member.util;
+
+import org.store.clothstar.member.dto.request.CreateMemberRequest;
+import org.store.clothstar.member.entity.MemberEntity;
+
+public class CreateObject {
+    public static CreateMemberRequest getCreateMemberRequest() {
+        String email = "test3@test.com";
+        String password = "testl122";
+        String name = "현수";
+        String telNo = "010-1234-1245";
+        String certifyNum = "asdf123";
+
+        CreateMemberRequest createMemberRequest = new CreateMemberRequest(
+                email, password, name, telNo, certifyNum
+        );
+
+        return createMemberRequest;
+    }
+
+    public static CreateMemberRequest getCreateMemberRequest(String email) {
+        String password = "testl122";
+        String name = "현수";
+        String telNo = "010-1234-1245";
+        String certifyNum = "asdf123";
+
+        CreateMemberRequest createMemberRequest = new CreateMemberRequest(
+                email, password, name, telNo, certifyNum
+        );
+
+        return createMemberRequest;
+    }
+
+
+    public static MemberEntity getMemberEntityByCreateMemberRequestDTO() {
+        return getCreateMemberRequest().toMemberEntity();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,6 +9,17 @@ spring:
       appender: com.p6spy.engine.spy.appender.Slf4JLogger
       logMessageFormat:
         p6spy: "%(currentTime)|%(executionTime)|%(category)|%(sqlSingleLine)"
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)
+    password: ENC(/hOuHdVpOgyzKrlqyayORlsTFpIrwe7RYnfAqXEFzIk=)
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
   jpa:
     hibernate:
@@ -26,3 +37,5 @@ jwt:
   secret_key: Y2xvdGhzaG9wcGluZ21hbGxjbG90aHN0YXJjbG90aHNob3BwaW5nbWFsbGNsb3Roc3RhcmNsb3Roc2hvcHBpbmdtYWxsY2xvdGhzdGFyY2xvdGhzaG9wcGluZ21hbGxjbG90aHN0YXIK
   accessTokenValidTimeMillis: 120000
   refreshTokenValidTimeMillis: 1200000
+
+email.send: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,6 +20,12 @@ spring:
           auth: true
           starttls:
             enable: true
+  # Redis
+  data:
+    redis:
+      host: ENC(GUuFDW7HjE98e7N28Vkb/xoIEgLeOCb5)
+      port: 6379
+      duration: 600
 
   jpa:
     hibernate:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,3 +39,4 @@ jwt:
   refreshTokenValidTimeMillis: 1200000
 
 email.send: ENC(kGXTSlfxUWNbRoGuBwNRTJBETjMz04AChYMrwDeY3Cs=)
+


### PR DESCRIPTION
이메일 인증완료.
[설명]
member 테이블에 enabled 컬럼 추가.
enabled의 true, false값으로 회원 활성화/비활성화

[process]
1. 회원가입시 입력한 이메일로 인증메일 전송
2. 회원가입하면 member 테이블에 가입 정보가 인입이 되고, enabled 필드값이 false로 자동으로 인입됨
4. 메일에서 링크 클릭하면 enabled 값이 true가 되면서 회원이 활성화됨

[의문점]
1. 이메일전송할때 URL root path값을 동적으로 하드코딩했는데, 동적으로 변경할수없는지.
2. JWT 토큰 사용할 필요가 있는지

[위 프로세스 수정]
redis 이용하여 메일로 전송된 인증코드 확인하여 회원가입