### PR TITLE
hotfix: 판매자 주문 조회 QueryDSL 관련 오류 수정

### DIFF
--- a/src/main/generated/org/store/clothstar/order/entity/QOrderEntity.java
+++ b/src/main/generated/org/store/clothstar/order/entity/QOrderEntity.java
@@ -28,8 +28,6 @@ public class QOrderEntity extends EntityPathBase<OrderEntity> {
 
     public final org.store.clothstar.member.entity.QMemberEntity member;
 
-    public final ListPath<org.store.clothstar.orderDetail.entity.OrderDetailEntity, org.store.clothstar.orderDetail.entity.QOrderDetailEntity> orderDetails = this.<org.store.clothstar.orderDetail.entity.OrderDetailEntity, org.store.clothstar.orderDetail.entity.QOrderDetailEntity>createList("orderDetails", org.store.clothstar.orderDetail.entity.OrderDetailEntity.class, org.store.clothstar.orderDetail.entity.QOrderDetailEntity.class, PathInits.DIRECT2);
-
     public final NumberPath<Long> orderId = createNumber("orderId", Long.class);
 
     public final EnumPath<org.store.clothstar.order.type.PaymentMethod> paymentMethod = createEnum("paymentMethod", org.store.clothstar.order.type.PaymentMethod.class);

--- a/src/main/java/org/store/clothstar/order/controller/OrderSellerController.java
+++ b/src/main/java/org/store/clothstar/order/controller/OrderSellerController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.store.clothstar.common.dto.MessageDTO;
 import org.store.clothstar.order.dto.reponse.OrderResponse;
+import org.store.clothstar.order.entity.OrderEntity;
 import org.store.clothstar.order.service.OrderSellerService;
 
 import java.util.List;
@@ -21,8 +22,8 @@ public class OrderSellerController {
 
     @Operation(summary = "(판매자) WAITING 주문 리스트 조회", description = "(판매자) 주문상태가 '승인대기'인 주문 리스트를 조회한다.")
     @GetMapping
-    public ResponseEntity<List<OrderResponse>> getWaitingOrder() {
-        List<OrderResponse> orderResponseList = orderSellerService.getWaitingOrder();
+    public ResponseEntity<List<OrderEntity>> getWaitingOrder() {
+        List<OrderEntity> orderResponseList = orderSellerService.getWaitingOrder();
         return ResponseEntity.ok(orderResponseList);
     }
 

--- a/src/main/java/org/store/clothstar/order/service/OrderSellerService.java
+++ b/src/main/java/org/store/clothstar/order/service/OrderSellerService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import org.store.clothstar.common.dto.MessageDTO;
 import org.store.clothstar.order.dto.reponse.OrderResponse;
+import org.store.clothstar.order.entity.OrderEntity;
 import org.store.clothstar.order.repository.order.OrderRepository;
 import org.store.clothstar.order.repository.orderSeller.JpaOrderSellerRepository;
 import org.store.clothstar.order.repository.orderSeller.OrderSellerRepository;
@@ -35,10 +36,9 @@ public class OrderSellerService {
     }
 
     @Transactional(readOnly = true)
-    public List<OrderResponse> getWaitingOrder() {
+    public List<OrderEntity> getWaitingOrder() {
 
         return orderSellerRepository.findWaitingOrders().stream()
-                .map(OrderResponse::fromOrderEntity)
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/org/store/clothstar/order/service/OrderSellerServiceTest.java
+++ b/src/test/java/org/store/clothstar/order/service/OrderSellerServiceTest.java
@@ -59,26 +59,26 @@ class OrderSellerServiceTest {
     void getWaitingOrder_test() {
         //given
         OrderEntity order1 = mock(OrderEntity.class);
-        given(order1.getCreatedAt()).willReturn(LocalDateTime.now());
+//        given(order1.getCreatedAt()).willReturn(LocalDateTime.now());
         given(order1.getTotalShippingPrice()).willReturn(1000);
-        given(order1.getMember()).willReturn(mockMemberEntity);
-        given(order1.getAddress()).willReturn(mockAddressEntity);
+//        given(order1.getMember()).willReturn(mockMemberEntity);
+//        given(order1.getAddress()).willReturn(mockAddressEntity);
 
         OrderEntity order2 = mock(OrderEntity.class);
-        given(order2.getCreatedAt()).willReturn(LocalDateTime.now());
-        given(order2.getMember()).willReturn(mockMemberEntity);
-        given(order2.getAddress()).willReturn(mockAddressEntity);
+//        given(order2.getCreatedAt()).willReturn(LocalDateTime.now());
+//        given(order2.getMember()).willReturn(mockMemberEntity);
+//        given(order2.getAddress()).willReturn(mockAddressEntity);
 
         OrderEntity order3 = mock(OrderEntity.class);
-        given(order3.getCreatedAt()).willReturn(LocalDateTime.now());
-        given(order3.getMember()).willReturn(mockMemberEntity);
-        given(order3.getAddress()).willReturn(mockAddressEntity);
+//        given(order3.getCreatedAt()).willReturn(LocalDateTime.now());
+//        given(order3.getMember()).willReturn(mockMemberEntity);
+//        given(order3.getAddress()).willReturn(mockAddressEntity);
 
         List<OrderEntity> orders = List.of(order1, order2, order3);
         given(orderSellerRepository.findWaitingOrders()).willReturn(orders);
 
         //when
-        List<OrderResponse> response = orderSellerService.getWaitingOrder();
+        List<OrderEntity> response = orderSellerService.getWaitingOrder();
 
         //then
         then(orderSellerRepository).should(times(1)).findWaitingOrders();


### PR DESCRIPTION
여러 findWaitingOrders() 메서드의 반환값이 OrderResponse와 OrderEntity로 나뉘어 있는 문제
 -> OrderEntity로 통일